### PR TITLE
Edited second user's email address

### DIFF
--- a/JAVASCRIPT-REST/client.php
+++ b/JAVASCRIPT-REST/client.php
@@ -49,7 +49,7 @@ $(document).ready(function() {
                             password : 'testpassword2',
                             firstname : 'testfirstname2',
                             lastname : 'testlastname2',
-                            email : 'testemail1@moodle.com',
+                            email : 'testemail2@moodle.com',
                             timezone : 'Pacific/Port_Moresby'
                          }
                      ];


### PR DESCRIPTION
This allows this user creation script to succeed whereas previously it would fail upon trying to create the second user as the email address 'testemail1@moodle.com' had already been used.
